### PR TITLE
Restrict project to XGB model

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,9 +45,9 @@ if __name__ == '__main__':
         ruta_modelos: str = rf"C:\Users\Álvaro\OneDrive\Escritorio\InfoRecursosBots\ModelosEntrenados"
         # Ejemplo de ruta para cargar un modelo específico (si se usara)
         # ruta_modelo_a_cargar: Optional[str] = os.path.join(ruta_modelos, "nombre_especifico.joblib")
-        ruta_modelo_a_cargar: Optional[str] = rf"C:\Users\Álvaro\OneDrive\Escritorio\InfoRecursosBots\ModelosEntrenados\modelo_entrenado_RANDOM_FOREST_BTCUSDC_2025-04-13_19-23-29.joblib" # Poner None para entrenar siempre uno nuevo
+        ruta_modelo_a_cargar: Optional[str] = rf"C:\Users\Álvaro\OneDrive\Escritorio\InfoRecursosBots\ModelosEntrenados\modelo_entrenado_XGB_BTCUSDC_2025-04-13_19-23-29.joblib" # Poner None para entrenar siempre uno nuevo
 
-        tipo_modelo_enum: Modelo = Modelo.RANDOM_FOREST # Elegir el modelo a entrenar/usar
+        tipo_modelo_enum: Modelo = Modelo.XGB  # Único modelo disponible
         metodo_target: TargetMethod = TargetMethod.ATR # Elegir método de target
         params_target: Dict[str, Any] = {} # Parámetros para el método de target (ej. {'umbral': 0.0015})
 

--- a/utils/enumerados.py
+++ b/utils/enumerados.py
@@ -18,12 +18,5 @@ class TargetMethod(Enum):
 
 
 class Modelo(Enum):
-    """Enumeración de los tipos de modelos de Machine Learning soportados."""
-    GRADIENT_BOOSTING = 1
-    RANDOM_FOREST = 2
-    XGB = 3
-
-    # Alternativa si los valores numéricos específicos no importan:
-    # GRADIENT_BOOSTING = auto()
-    # RANDOM_FOREST = auto()
-    # XGB = auto()
+    """Tipo de modelo de Machine Learning a utilizar."""
+    XGB = 1


### PR DESCRIPTION
## Summary
- streamline model selection to only allow the XGB classifier
- update builder and trainer to remove RandomForest and GradientBoosting
- adjust main to reflect new default model
- simplify model enumeration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845fa82b8a0832e84da52da20ab1249